### PR TITLE
Added removed translations back to labels.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,7 +117,7 @@ class Plugin {
       list($name, $label, $field, $taxonomy) = $field;
       $fieldParameters[] = [
         'key' => $field ? 'field_' . strtr($name, '-', '_') : $name,
-        'label' => $label,
+        'label' => __($label, Plugin::L10N),
         'name' => $name,
         'type' => 'relationship',
         'post_type' => ['product'],


### PR DESCRIPTION
Slack discussion: https://netzstrategen.slack.com/archives/CAMP1MQJ2/p1628515985001400?thread_ts=1627635558.000900&cid=CAMP1MQJ2

Alternative PR to https://github.com/netzstrategen/woocommerce-related-accessories/pull/6
Adds back what was removed in https://github.com/netzstrategen/woocommerce-related-accessories/pull/4