### PR TITLE
Fixed incorrect argument type in array_filter.

### DIFF
--- a/templates/related-accessories.php
+++ b/templates/related-accessories.php
@@ -26,7 +26,7 @@ global $product, $post;
         }
       ?>
       <?php if ($group_name !== 'all') :
-        $field_label = array_filter($fields_labels, function ($field, $index) use ($group_name) {
+        $field_label = array_filter((array) $fields_labels, function ($field, $index) use ($group_name) {
           return $index === $group_name || $index === 'field_' . $group_name;
         }, ARRAY_FILTER_USE_BOTH);
         ?>


### PR DESCRIPTION
https://app.asana.com/0/30156186242982/1201756522988465/f

Tideways error:

array_filter(): Argument 1 ($array) must be of type array, null given

https://app.tideways.io/o/netzstrategen/gaco-live/issues/errors?error=13077-137bf8cff2d59f0883c600f9524b3eed&offset=0&page=1