### PR TITLE
Fixed PHP Warning: Undefined variable $fields_labels.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.7",
+  "version": "1.1.8",
   "title": "woocommerce-related-accessories",
   "description": "Displays a list of related accessories on product single page.",
   "dependencies": {

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: WooCommerce Related Accessories
-  Version: 1.1.7
+  Version: 1.1.8
   Text Domain: woocommerce-related-accessories
   Description: Displays a list of related accessories on product single page.
   Author: netzstrategen

--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -58,6 +58,7 @@ class WooCommerce {
 
     $related_accessories = static::buildRelatedProductsView($related_accessories_ids);
     Plugin::renderTemplate(['templates/related-accessories.php'], [
+      'fields_labels' => wc_list_pluck(acf_get_local_fields('field_group_related_accessories'), 'label'),
       'related_accessories' => $related_accessories,
       'is_notice_template' => TRUE,
     ]);


### PR DESCRIPTION
[Various PHP Fatal errors, errors, warnings](https://app.asana.com/0/809933051638353/1202430764055301)

Details
- The theme template tries to render group labels in `$field_labels` https://github.com/netzstrategen/woocommerce-related-accessories/blob/5e85a33c8b2cd18d797fc691dcb4d2de9f6169cc/templates/related-accessories.php#L29 but in the second case where the template is used (on the product page, before adding a product to the cart), the variable is not passed to the template: https://github.com/netzstrategen/woocommerce-related-accessories/blob/5e85a33c8b2cd18d797fc691dcb4d2de9f6169cc/src/WooCommerce.php#L49-L63